### PR TITLE
Gp integration with m rto gz

### DIFF
--- a/launch/prop_mapper_sim.launch
+++ b/launch/prop_mapper_sim.launch
@@ -21,6 +21,7 @@
 
   <node name="coord_finder" pkg="prop_mapper" type="coord_finder" output="screen">
     <rosparam file="$(find prop_mapper)/config/params.yaml" command="load" />
+    <remap from="/mavros/local_position/pose" to="/gazebo_pose">
   </node>
 
   <node name="prop_map" pkg="prop_mapper" type="prop_map" output="screen">

--- a/src/coord_finder.cpp
+++ b/src/coord_finder.cpp
@@ -68,13 +68,7 @@ private:
         double cosy_cosp = 1 - 2 * (q.y * q.y + q.z * q.z);
         double yaw = std::atan2(siny_cosp, cosy_cosp);
 
-        // convert to gazebo heading
-        double heading = yaw - (M_PI/2);
-        if (heading < 0)
-        {
-            heading = heading + (2*M_PI);
-        }
-        return heading;
+        return yaw;
     }
 
     /**
@@ -107,8 +101,8 @@ private:
         double prop_y_aligned = radius*sin(angle-((M_PI/2)-heading));
 
 
-        double prop_x =  pose_msg_.pose.position.y + prop_x_aligned;
-        double prop_y =  -pose_msg_.pose.position.x + prop_y_aligned;
+        double prop_x =  pose_msg_.pose.position.x + prop_x_aligned;
+        double prop_y =  pose_msg_.pose.position.y + prop_y_aligned;
 
         // Create and publish the Prop message with the prop's local coordinates 
         prop_mapper::Prop local_prop_msg;


### PR DESCRIPTION
Integration with updated task master, no longer handles the gazebo heading conversion because that's now done in task master. Adds a remap to the sim launch file so it listens to gazebo pose when in sim. 